### PR TITLE
Fix flyover menu key error

### DIFF
--- a/components/DropdownMenu.tsx
+++ b/components/DropdownMenu.tsx
@@ -1,4 +1,3 @@
-import { Popover } from "@headlessui/react"
 import { useRef, useEffect, useState } from "react"
 import PropTypes from "prop-types"
 import FlyoutMenu from "@/components/FlyoutMenu"
@@ -82,11 +81,8 @@ export default function DropdownMenu() {
       <OutsideAlerter>
         {/* OutsideAlerter is for the mobile menu --
         close with toggle or by clicking outside */}
-        <Popover.Group
-          as="nav"
-          role="navigation"
-          className="flex flex-col items-center"
-        >
+        {/*as="nav"*/}
+        <nav role="navigation" className="flex flex-col items-center">
           <button
             type="button"
             aria-label="Toggle Menu"
@@ -128,18 +124,18 @@ export default function DropdownMenu() {
             {NAVIGATION_MENU.map(
               ([title, hrefOrSubmenu]: NAVIGATION_MENU_TYPE) => {
                 return (
-                  <Popover.Group key={title as string}>
-                    <FlyoutMenu
-                      title={title as string}
-                      hrefOrSubmenu={hrefOrSubmenu as NAVIGATION_MENU_TYPE}
-                      layout="outer"
-                    />
-                  </Popover.Group>
+                  <FlyoutMenu
+                    title={title as string}
+                    hrefOrSubmenu={hrefOrSubmenu as NAVIGATION_MENU_TYPE}
+                    layout="outer"
+                    key={"FlyoutMenu" + title}
+                    parent={"@/"}
+                  />
                 )
               }
             )}
           </div>
-        </Popover.Group>
+        </nav>
       </OutsideAlerter>
     </>
   )

--- a/components/FlyoutMenu.tsx
+++ b/components/FlyoutMenu.tsx
@@ -199,7 +199,7 @@ export default function FlyoutMenu({
                               : undefined
                           return (
                             <React.Fragment
-                              key={"PopoverPanel<div><div>" + parent + title}
+                              key={"PopoverPanel<>" + parent + title}
                             >
                               {href && (
                                 <Link

--- a/components/FlyoutMenu.tsx
+++ b/components/FlyoutMenu.tsx
@@ -1,5 +1,5 @@
 /* This example requires Tailwind CSS v2.0+ */
-import { Fragment, useRef } from "react"
+import React, { Fragment, useRef } from "react"
 import { Popover, Transition } from "@headlessui/react"
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/solid"
 import Link from "@/components/Link"
@@ -198,7 +198,7 @@ export default function FlyoutMenu({
                               ? hrefOrSubmenu
                               : undefined
                           return (
-                            <div
+                            <React.Fragment
                               key={"PopoverPanel<div><div>" + parent + title}
                             >
                               {href && (
@@ -228,7 +228,7 @@ export default function FlyoutMenu({
                                   parent={parent + (title as string)}
                                 />
                               )}
-                            </div>
+                            </React.Fragment>
                           )
                         }
                       )}

--- a/components/FlyoutMenu.tsx
+++ b/components/FlyoutMenu.tsx
@@ -63,11 +63,14 @@ export default function FlyoutMenu({
   title,
   hrefOrSubmenu,
   layout,
+  parent,
 }: {
   title: string
   hrefOrSubmenu: NAVIGATION_MENU_TYPE | string
   layout: "outer" | "inner"
+  parent: string
 }) {
+  console.log(parent)
   const timeoutDuration = 200
   let timeout: NodeJS.Timeout
   const useHover = true
@@ -96,9 +99,9 @@ export default function FlyoutMenu({
   return (
     <>
       {typeof hrefOrSubmenu === "string" && (
-        <Popover className="relative">
+        <Popover className="relative" key={"Popover" + parent + title}>
           <Link
-            key={title + hrefOrSubmenu}
+            key={parent + title + hrefOrSubmenu}
             href={hrefOrSubmenu}
             className={classNames(
               partOfCurrentPagePath(title, hrefOrSubmenu, currentPagePath)
@@ -113,11 +116,12 @@ export default function FlyoutMenu({
         </Popover>
       )}
       {typeof hrefOrSubmenu === "object" && (
-        <Popover className="relative">
+        <Popover className="relative" key={"Popover" + parent + title}>
           {({ open }) => (
             <div
               onMouseEnter={() => useHover && onMouseHover(!open)}
               onMouseLeave={() => useHover && onMouseHover(open)}
+              key={"Popover<div>" + parent + title}
             >
               <Popover.Button
                 className={classNames(
@@ -129,6 +133,7 @@ export default function FlyoutMenu({
                   LINK_STYLES
                 )}
                 ref={buttonRef}
+                key={"PopoverButton" + parent + title}
               >
                 <span className="uppercase">{title}</span>
                 {layout === "outer" && (
@@ -160,6 +165,7 @@ export default function FlyoutMenu({
                 leave="transition ease-in duration-150"
                 leaveFrom="opacity-100 translate-y-0"
                 leaveTo="opacity-0 translate-y-1"
+                key={"Transition" + parent + title}
               >
                 <Popover.Panel
                   static
@@ -170,6 +176,7 @@ export default function FlyoutMenu({
                       "absolute left-[-1.75rem] z-10 w-64 px-2 mt-2") as string
                   )}
                   ref={dropdownRef}
+                  key={"PopoverPanel" + parent + title}
                 >
                   <div
                     className={classNames(
@@ -178,6 +185,7 @@ export default function FlyoutMenu({
                       (layout === "outer" &&
                         "relative grid space-y-[2px] bg-white border-2 border-gray-300 border-solid divide-y-2 rounded-md") as string
                     )}
+                    key={"PopoverPanel<div>" + parent + title}
                   >
                     {typeof hrefOrSubmenu === "object" &&
                       (hrefOrSubmenu as NAVIGATION_MENU_TYPE[]).map(
@@ -191,10 +199,12 @@ export default function FlyoutMenu({
                               ? hrefOrSubmenu
                               : undefined
                           return (
-                            <>
+                            <div
+                              key={"PopoverPanel<div><div>" + parent + title}
+                            >
                               {href && (
                                 <Link
-                                  key={title + href}
+                                  key={"Link" + title + href + parent}
                                   href={href}
                                   className={classNames(
                                     partOfCurrentPagePath(
@@ -211,15 +221,15 @@ export default function FlyoutMenu({
                                 </Link>
                               )}
                               {submenu && (
-                                <Popover.Group>
-                                  <FlyoutMenu
-                                    title={title as string}
-                                    hrefOrSubmenu={submenu}
-                                    layout="inner"
-                                  />
-                                </Popover.Group>
+                                <FlyoutMenu
+                                  title={title as string}
+                                  hrefOrSubmenu={submenu}
+                                  layout="inner"
+                                  key={"FlyoutMenu" + title}
+                                  parent={parent + (title as string)}
+                                />
                               )}
-                            </>
+                            </div>
                           )
                         }
                       )}

--- a/components/FlyoutMenu.tsx
+++ b/components/FlyoutMenu.tsx
@@ -70,7 +70,6 @@ export default function FlyoutMenu({
   layout: "outer" | "inner"
   parent: string
 }) {
-  console.log(parent)
   const timeoutDuration = 200
   let timeout: NodeJS.Timeout
   const useHover = true


### PR DESCRIPTION
React Fragment was missing key; added keys exhaustively

TabIndex bug reported but unsolved -- see discussion tailwindlabs/headlessui#467