### PR TITLE
Add markdown format to link util helper

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -87,7 +87,10 @@ export default function Footer() {
           <div className="footer-bot">
             <div className="text-base">
               <div id="plemx-root" />
-              <Link href="https://www.theweathernetwork.com">
+              <Link
+                href="https://www.theweathernetwork.com"
+                className="text-gray-900"
+              >
                 The Weather Network
               </Link>
             </div>

--- a/components/HoverBullet.tsx
+++ b/components/HoverBullet.tsx
@@ -32,6 +32,7 @@ export default function HoverBullet({
         <Link
           href={href as string}
           className={classNames(
+            "text-black",
             hover || isCurrentPage ? "underline" : "no-underline"
           )}
         >

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -19,9 +19,9 @@ const CustomLink = ({
 
   // add default Tailwind classes to Link styles
   className = className ? className : "" // handle undefined
-  className = className.includes("underline") // handle "no-underline"
+  className = className.includes("underline") // handle "underline"
     ? className
-    : classNames(className, "underline")
+    : classNames(className, "no-underline hover:underline")
   className = className.includes("text-") // handle "text-black"
     ? className
     : classNames(className, "text-blue-brand")

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 import Link from "next/link"
+import { classNames } from "@/lib/utils"
 
 const CustomLink = ({
   href,
@@ -15,6 +16,15 @@ const CustomLink = ({
 }) => {
   const isInternalLink = href && href.startsWith("/")
   const isAnchorLink = href && href.startsWith("#")
+
+  // add default Tailwind classes to Link styles
+  className = className ? className : "" // handle undefined
+  className = className.includes("underline") // handle "no-underline"
+    ? className
+    : classNames(className, "underline")
+  className = className.includes("text-") // handle "text-black"
+    ? className
+    : classNames(className, "text-blue-brand")
 
   if (isInternalLink) {
     return (

--- a/data/campgrounds.md
+++ b/data/campgrounds.md
@@ -43,14 +43,13 @@ pricingPackagesBlueFootnotes:
     { footnoteLabel: "1", description: "Connection limited to one device" },
     {
       footnoteLabel: "2",
-      description: 'Connection limited to two devices – Please <Link href="contact">call</Link> to activate second device',
+      description: "Connection limited to two devices – Please [call](/contact) to activate second device",
     },
     {
       footnoteLabel: "*",
       description: "Credit card required for all packages",
     },
   ]
-pricingPackagesSectionDetails: 'Connection limited to two devices – Please <Link href="contact">call</Link> to activate second device'
 ---
 
 ### KOS is offering wireless internet service at the following campgrounds in Ontario:

--- a/layouts/PricingPageLayout.tsx
+++ b/layouts/PricingPageLayout.tsx
@@ -277,7 +277,7 @@ export default function PricingPageLayout({
           <>
             <div className="pb-4 text-2xl font-semibold tracking-tight color">
               Please{" "}
-              <Link href="/contact" className="hover:underline">
+              <Link href="/contact" className="text-black">
                 contact our office
               </Link>{" "}
               for more information, or select from one of our services below.

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -64,26 +64,42 @@ export const formatFootnotesAsSuperscriptIfPresent = (stringToTest: string) => {
 
 /**
  * Add a Next.js <Link> to replace a single <a> or <Link> found in the
- * given string, if any. Full Markdown support is not wanted here.
+ * given string, if any. Full Markdown support is not wanted here, but
+ * Markdown format of [title](https://www.example.com) is supported.
+ *
  * @returns JSX Element including the correct <Link href=""> element
  */
 export const addLinkToTextIfPresent = (stringToTest: string) => {
   const linkRegExp =
     /(.*)<[aL]i?n?k?.+href=['"](.+)['"].*>(.+)<\/[aL]i?n?k?>(.*)/
-  const matchResults = linkRegExp.exec(stringToTest)
-  if (matchResults) {
-    const [, before, href, linkText, after] = matchResults
+  const linkMatchResults = linkRegExp.exec(stringToTest)
+  if (linkMatchResults) {
+    const [, before, href, linkText, after] = linkMatchResults
     if (href && linkText) {
       return (
         <>
           {before}
-          <Link href={href} className="underline text-blue-brand">
-            {linkText}
-          </Link>
+          <Link href={href}>{linkText}</Link>
           {after}
         </>
       )
     }
   }
+
+  const markdownRegExp = /(.*)\[(.+)\]\((.+)\)(.*)/
+  const markdownMatchResults = markdownRegExp.exec(stringToTest)
+  if (markdownMatchResults) {
+    const [, before, linkText, href, after] = markdownMatchResults
+    if (href && linkText) {
+      return (
+        <>
+          {before}
+          <Link href={href}>{linkText}</Link>
+          {after}
+        </>
+      )
+    }
+  }
+
   return <>{stringToTest}</>
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -139,9 +139,10 @@ module.exports = {
           css: {
             color: "black",
             a: {
-              color: theme("colors.blue.500"),
+              color: theme("colors.blue.brand"),
+              textDecoration: "none",
               "&:hover": {
-                color: theme("colors.blue.600"),
+                textDecoration: "underline",
               },
             },
             h1: {


### PR DESCRIPTION
✅Handle Markdown links [title](URL) in util helper
✅Add default <Link> styles and fix resulting inconsistent link styles
✅Fix default <a> style in prose class (Tailwind typography)
✅Example from /campgrounds
![image](https://user-images.githubusercontent.com/761231/124034920-73d22700-d9c1-11eb-8efb-7b2581204b94.png)
